### PR TITLE
Use of level instead of level-11, display data on a new line if key.length > limit

### DIFF
--- a/bin/level
+++ b/bin/level
@@ -5,7 +5,7 @@
  */
 
 var repl = require('repl');
-var level = require('level-11');
+var level = require('level');
 var minimist = require('minimist');
 var chalk = require('chalk');
 var gtor = require('glob-to-regexp');
@@ -101,7 +101,12 @@ actions.get = function(args, fn) {
       var key = data.key;
       if (!rkey.test(string(key))) return;
       val = rjson.test(val) ? pj.render(JSON.parse(val)) : val;
-      val = val.replace(/\n/g, '\n      ' + repeat(' ', key.length))
+      if (key.length >= 80) {
+          var off = '\n      ';
+          val = off + val.replace(/\n/g, off);
+      } else {
+          val = val.replace(/\n/g, '\n      ' + repeat(' ', key.length));
+      }
       console.log('\n  %s => %s\n', chalk.red(unstring(key)), val);
     });
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "chalk": "^0.5.1",
     "glob-to-regexp": "0.0.1",
-    "level-11": "^0.18.0",
+    "level": "*",
     "minimist": "^1.1.0",
     "prettyjson": "^1.0.0"
   },


### PR DESCRIPTION
Hi there,
This pull request is only for two minor changes
- level-11 is blocked on a level-down version which does not compile on some recent systems. So the proposal is to use level which does the same thing but seems to be more used and more up to date
- for those who have long keys (this is my case :) ), there is a limit in length (currently at 80) whereupon data is displayed on a new line.
  By the way, thank you for your package :)
